### PR TITLE
Fixes "submit" run type. Adds entropy-source-metadata.json template.

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -200,7 +200,8 @@ if __name__ == "__main__":
         ea.send_reg()
         responseCount=0
         for response in ea.responses:
-            ThreadWrapper.runner_data(server_url, response, conditioned[responseCount], raw_noise[responseCount], restart_test[responseCount], client_cert, rawNoiseSampleSize)
+            ThreadWrapper.runner_data(server_url, response, conditioned[responseCount], raw_noise[responseCount], restart_test[responseCount], client_cert, rawNoiseSampleSize[responseCount], restartSampleSize[responseCount])
+            # ThreadWrapper.runner_stats(server_url, response, client_cert)
             responseCount = responseCount + 1
             
     #Send Supporting Documentation

--- a/client/jsons/entropy-source-metadata.json
+++ b/client/jsons/entropy-source-metadata.json
@@ -1,0 +1,30 @@
+[
+	{
+		"esvVersion": "1.0"
+	},
+	{
+		"primaryNoiseSource": <string, brief description of noise source (32 characters)>,
+		"iidClaim": <true or false, whether an IID claim is made on the noise source>,
+		"bitsPerSample": <integer, number of bits in a sample output of the full entropy source [1, 8], if above 8, please use 8>,
+		"hminEstimate": <double, estimate of the entropy in one sample out of the full entropy source>,
+		"physical": <true or false, whether the entropy source is physical or non-physical>,
+		"numberOfRestarts": <integer, number of restarts used to perform the restart tests>,
+		"samplesPerRestart": <integer, number of samples generated per restart to perform the restart tests>,
+		"additionalNoiseSources": <true or false, whether the entropy source includes additional noise sources according to Section 3.1.6 of SP 800-90B>,
+		"numberOfOEs": <integer, number of OEs>,
+		"conditioningComponent": [
+			{
+				"sequencePosition": <integer, ordered list with other conditioning components on where in the sequence of operations the individual component occurs, must be 1, 2, ...n for n elements in this array>
+                "vetted": <true or false, whether the conditioning components meets the SP 800-90B definition of vetted>,
+                "description": <string, brief description of the conditioning component, or if vetted, the ACVP algorithm name>,
+                "validationNumber": <string, if vetted, the ACVP validation certificate number>,
+                "bijectiveClaim": <true or false, if non-vetted, whether the conditioning component is claimed to be bijective>,
+                "minNin": <integer, minimum number of bits required to run the conditioning component>,
+                "minHin": <double, minimum amount of entropy required to run the conditioning component>,
+                "nw": <integer, narrowest width of the conditioning component>,
+                "nOut": <integer, output size in bits of the conditioning component>
+				"hOut": <integer, output size in bits of the entropy>
+			}
+		]
+	}
+]


### PR DESCRIPTION
Recently I had to use this client to submit some samples for a ESV in progress. In using this client I ran into some issues with the 'submit' run type.

First was that on line `203` the call for the `runner_data` was missing the `restartSampleSize` variable.

Second also on line `203` the `runner_data` function call was passing `rawNoiseSampleSize`. This value is a list, not a value. So when the trace is followed and `df_upload_raw` is called. The check on line 62 from `thread_functions.py` `if(sampleSize != -1)` was comparing if a list is equal to -1. This lead to always doing:

```
files= { 
            'dataFile': (os.path.basename(raw_noise),open(raw_noise,'rb'),'application/octet-stream'),
            'DataFileSampleSize': sampleSize }
```
Which passed a list instead of the intended sampleSize integer. This lead to a parsing error on line 70 from `thread_functions.py` and threw an error.

To fix this I added the `restartSampleSize` argument to the `runner_data` call on line 203 of `client.py`. Secondly I copied what was done in the `full` run type and used the `responseCount` variable already present to pass: `rawNoiseSampleSize[responseCount], restartSampleSize[responseCount]` which passes the values of the rawNoiseSampleSize and restartSampleSize for the respective respone instead of the list of sample sizes. 

I tested this with:
 - 1 oe with and without the `rawNoiseSampleSize` and `restartSampleSize` json values given in a run.demo.json.
 - 2 oes with and without the `rawNoiseSampleSize` and `restartSampleSize` json values given in a run.demo.json.

Additionally I added a template for the `jsons/entropy-source-metadata.json` . Documentation for this addition was not added.